### PR TITLE
Impermanence compatible disko

### DIFF
--- a/modules/home/desktop/wayland/default.nix
+++ b/modules/home/desktop/wayland/default.nix
@@ -10,7 +10,7 @@
       imports = with config.flake.modules.homeManager; [
         fuzzel
         gammastep
-	swaync
+        swaync
         swayosd
       ];
 

--- a/modules/hosts/baratie/disko.nix
+++ b/modules/hosts/baratie/disko.nix
@@ -1,86 +1,86 @@
 {
-  flake.modules.nixos."nixosConfigurations/baratie" = 
-  { pkgs, ... }:
-  {
-    boot.supportedFilesystems = [ "zfs" ];
-    # /dev/disk/by-id doesn't seem to work on virtual disks
-    boot.zfs.devNodes = "/dev/disk/by-uuid";
-    networking.hostId = "8425e349";
-    disko.devices = {
-      disk = {
-        main = {
-          device = "/dev/vda";
-          type = "disk";
-          content = {
-            type = "gpt";
-            partitions = {
-	      boot = {
-	        size = "1M";
-		type = "EF02"; # MBR grub
-	      };
-              ESP = {
-                size = "1G";
-                type = "EF00";
-                content = {
-                  type = "filesystem";
-                  format = "vfat";
-                  mountpoint = "/boot";
-                  mountOptions = [ "umask=0077" ];
+  flake.modules.nixos."nixosConfigurations/baratie" =
+    { pkgs, ... }:
+    {
+      boot.supportedFilesystems = [ "zfs" ];
+      # /dev/disk/by-id doesn't seem to work on virtual disks
+      boot.zfs.devNodes = "/dev/disk/by-uuid";
+      networking.hostId = "8425e349";
+      disko.devices = {
+        disk = {
+          main = {
+            device = "/dev/vda";
+            type = "disk";
+            content = {
+              type = "gpt";
+              partitions = {
+                boot = {
+                  size = "1M";
+                  type = "EF02"; # MBR grub
                 };
-              };
-              zfs = {
-                size = "100%";
-                content = {
-                  type = "zfs";
-                  pool = "zroot";
+                ESP = {
+                  size = "1G";
+                  type = "EF00";
+                  content = {
+                    type = "filesystem";
+                    format = "vfat";
+                    mountpoint = "/boot";
+                    mountOptions = [ "umask=0077" ];
+                  };
+                };
+                zfs = {
+                  size = "100%";
+                  content = {
+                    type = "zfs";
+                    pool = "zroot";
+                  };
                 };
               };
             };
           };
         };
-      };
-      zpool = {
-        zroot = {
-          type = "zpool";
-          rootFsOptions = {
-            acltype = "posixacl";
-            atime = "off";
-            compression = "zstd";
-	    mountpoint = "none";
-            xattr = "sa";
-          };
-          options.ashift = "12";
+        zpool = {
+          zroot = {
+            type = "zpool";
+            rootFsOptions = {
+              acltype = "posixacl";
+              atime = "off";
+              compression = "zstd";
+              mountpoint = "none";
+              xattr = "sa";
+            };
+            options.ashift = "12";
 
-          datasets = {
-	    "local" = {
-	      type = "zfs_fs";
-	      options.mountpoint = "none";
-	    };
-	    "local/nix" = {
-	      type = "zfs_fs";
-	      mountpoint = "/nix";
-	      options."com.sun:auto-snapshot" = "false";
-	    };
-            "local/root" = {
-	        type = "zfs_fs";
-	        mountpoint = "/";
-	        options."com.sun:auto-snapshot" = "false";
-	        postCreateHook = "zfs list -t snapshot -H -o name | grep -E '^zroot/local/root@blank$' || zfs snapshot zroot/local/root@blank";
-	    };
+            datasets = {
+              "local" = {
+                type = "zfs_fs";
+                options.mountpoint = "none";
+              };
+              "local/nix" = {
+                type = "zfs_fs";
+                mountpoint = "/nix";
+                options."com.sun:auto-snapshot" = "false";
+              };
+              "local/root" = {
+                type = "zfs_fs";
+                mountpoint = "/";
+                options."com.sun:auto-snapshot" = "false";
+                postCreateHook = "zfs list -t snapshot -H -o name | grep -E '^zroot/local/root@blank$' || zfs snapshot zroot/local/root@blank";
+              };
 
-	    # backed up datasets
-	    "safe" = {
-	      type = "zfs_fs";
-	      options.mountpoint = "none";
-	    };
-	    "safe/persist" = {
-	      type = "zfs_fs";
-	      mountpoint = "/persist";
-	      options."com.sun:auto-snapshot" = "false";
-	    };
+              # backed up datasets
+              "safe" = {
+                type = "zfs_fs";
+                options.mountpoint = "none";
+              };
+              "safe/persist" = {
+                type = "zfs_fs";
+                mountpoint = "/persist";
+                options."com.sun:auto-snapshot" = "false";
+              };
+            };
           };
         };
       };
     };
-  };
 }

--- a/modules/hosts/baratie/wireguard/default.nix
+++ b/modules/hosts/baratie/wireguard/default.nix
@@ -10,7 +10,7 @@
         wg-proxy = {
           ips = [ "10.0.0.1/24" ];
           listenPort = port;
-	  generatePrivateKeyFile = true;
+          generatePrivateKeyFile = true;
           privateKeyFile = "/persist/etc/wireguard/wg-proxy";
           peers = [
             {

--- a/modules/hosts/merry/disko.nix
+++ b/modules/hosts/merry/disko.nix
@@ -1,0 +1,80 @@
+{
+  flake.modules.nixos."nixosConfigurations/sunny" = {
+    boot.supportedFilesystems = [ "zfs" ];
+    networking.hostId = "af7bc4fa";
+    disko.devices = {
+      disk = {
+        nvme0n1 = {
+          device = "/dev/nvme0n1";
+          type = "disk";
+          content = {
+            type = "gpt";
+            partitions = {
+              ESP = {
+                size = "1G";
+                type = "EF00";
+                content = {
+                  type = "filesystem";
+                  format = "vfat";
+                  mountpoint = "/boot";
+                  mountOptions = [ "umask=0077" ];
+                };
+              };
+              zfs = {
+                size = "100%";
+                content = {
+                  type = "zfs";
+                  pool = "zroot";
+                };
+              };
+            };
+          };
+        };
+      };
+      # Configure zpool/datasets
+      zpool = {
+        zroot = {
+          type = "zpool";
+          rootFsOptions = {
+            acltype = "posixacl";
+            atime = "off";
+            compression = "zstd";
+            mountpoint = "none";
+            xattr = "sa";
+          };
+          options.ashift = "13";
+
+          datasets = {
+            "local" = {
+              type = "zfs_fs";
+              options.mountpoint = "none";
+            };
+            "local/nix" = {
+              type = "zfs_fs";
+              mountpoint = "/nix";
+            };
+            "local/root" = {
+              type = "zfs_fs";
+              mountpoint = "/";
+              postCreateHook = "zfs list -t snapshot -H -o name | grep -E '^zroot/local/root@blank$' || zfs snapshot zroot/local/root@blank";
+            };
+
+            # backed up datasets
+            "safe" = {
+              type = "zfs_fs";
+              options.mountpoint = "none";
+            };
+            "safe/persist" = {
+              type = "zfs_fs";
+              mountpoint = "/persist";
+            };
+            "safe/home" = {
+              type = "zfs_fs";
+              mountpoint = "/home";
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/modules/hosts/merry/disko.nix
+++ b/modules/hosts/merry/disko.nix
@@ -1,5 +1,5 @@
 {
-  flake.modules.nixos."nixosConfigurations/sunny" = {
+  flake.modules.nixos."nixosConfigurations/merry" = {
     boot.supportedFilesystems = [ "zfs" ];
     networking.hostId = "af7bc4fa";
     disko.devices = {

--- a/modules/hosts/merry/filesystems.nix
+++ b/modules/hosts/merry/filesystems.nix
@@ -2,27 +2,27 @@
   flake.modules.nixos."nixosConfigurations/merry" = {
     boot.initrd.availableKernelModules = [ "nvme" ];
 
-    fileSystems."/" = {
-      device = "/dev/disk/by-uuid/ace8816b-1ea5-444a-8d94-7a4381834abf";
-      fsType = "ext4";
-    };
-
-    boot.initrd.luks.devices."luks-5fd805ab-c1dd-4ab7-8e47-c029d4e30996".device =
-      "/dev/disk/by-uuid/5fd805ab-c1dd-4ab7-8e47-c029d4e30996";
-    boot.initrd.luks.devices."luks-6479d9bf-f8ed-40cd-a533-6f37bf1d5712".device =
-      "/dev/disk/by-uuid/6479d9bf-f8ed-40cd-a533-6f37bf1d5712";
-
-    fileSystems."/boot" = {
-      device = "/dev/disk/by-uuid/6454-F28F";
-      fsType = "vfat";
-      options = [
-        "fmask=0022"
-        "dmask=0022"
-      ];
-    };
-
-    swapDevices = [
-      { device = "/dev/disk/by-uuid/28f209f9-5b4e-4d20-be16-41a15ba59037"; }
-    ];
+    # fileSystems."/" = {
+    #   device = "/dev/disk/by-uuid/ace8816b-1ea5-444a-8d94-7a4381834abf";
+    #   fsType = "ext4";
+    # };
+    #
+    # boot.initrd.luks.devices."luks-5fd805ab-c1dd-4ab7-8e47-c029d4e30996".device =
+    #   "/dev/disk/by-uuid/5fd805ab-c1dd-4ab7-8e47-c029d4e30996";
+    # boot.initrd.luks.devices."luks-6479d9bf-f8ed-40cd-a533-6f37bf1d5712".device =
+    #   "/dev/disk/by-uuid/6479d9bf-f8ed-40cd-a533-6f37bf1d5712";
+    #
+    # fileSystems."/boot" = {
+    #   device = "/dev/disk/by-uuid/6454-F28F";
+    #   fsType = "vfat";
+    #   options = [
+    #     "fmask=0022"
+    #     "dmask=0022"
+    #   ];
+    # };
+    #
+    # swapDevices = [
+    #   { device = "/dev/disk/by-uuid/28f209f9-5b4e-4d20-be16-41a15ba59037"; }
+    # ];
   };
 }

--- a/modules/hosts/merry/hardware.nix
+++ b/modules/hosts/merry/hardware.nix
@@ -16,7 +16,7 @@
 
       boot = {
         # Use latest linux kernel
-        kernelPackages = pkgs.linuxPackages_latest;
+        # kernelPackages = pkgs.linuxPackages_latest;
 
         initrd = {
           availableKernelModules = [

--- a/modules/hosts/sunny/disko.nix
+++ b/modules/hosts/sunny/disko.nix
@@ -1,6 +1,6 @@
 {
   flake.modules.nixos."nixosConfigurations/sunny" =
-    { pkgs, lib, ... }:
+    { lib, ... }:
     let
       diskNames = [
         "nvme0n1"

--- a/modules/hosts/sunny/disko.nix
+++ b/modules/hosts/sunny/disko.nix
@@ -1,0 +1,105 @@
+{
+  flake.modules.nixos."nixosConfigurations/sunny" =
+    { pkgs, lib, ... }:
+    let
+      diskNames = [
+        "nvme0n1"
+        "nvme1n1"
+        "nvme2n1"
+      ];
+      raidzContent = {
+        type = "gpt";
+        partitions = {
+          ESP = {
+            size = "1G";
+            type = "EF00";
+            content = {
+              type = "filesystem";
+              format = "vfat";
+              mountpoint = "/boot";
+              mountOptions = [ "umask=0077" ];
+            };
+          };
+          zfs = {
+            size = "100%";
+            content = {
+              type = "zfs";
+              pool = "zroot";
+            };
+          };
+        };
+      };
+    in
+    {
+      # boot.supportedFilesystems = [ "zfs" ];
+      networking.hostId = "0ffc592e";
+      disko.devices = {
+        # Create mirrored partitions on all disks
+        disk = builtins.listToAttrs (
+          lib.imap0 (index: name: {
+            inherit name;
+            value = {
+              type = "disk";
+              device = "/dev/${name}";
+              content = raidzContent // {
+                partitions = raidzContent.partitions // {
+                  ESP = raidzContent.partitions.ESP // {
+                    content = raidzContent.partitions.ESP.content // {
+                      mountpoint = # nvme1n1's ESP is mounted at /boot1, etc.
+                        raidzContent.partitions.ESP.content.mountpoint
+                        + (if index == 0 then "" else builtins.toString index);
+                    };
+                  };
+                };
+              };
+            };
+          }) diskNames
+        );
+        # Configure zpool/datasets
+        zpool = {
+          zroot = {
+            type = "zpool";
+            mode = "raidz";
+            rootFsOptions = {
+              acltype = "posixacl";
+              atime = "off";
+              compression = "zstd";
+              mountpoint = "none";
+              xattr = "sa";
+            };
+            options.ashift = "13";
+
+            datasets = {
+              "local" = {
+                type = "zfs_fs";
+                options.mountpoint = "none";
+              };
+              "local/nix" = {
+                type = "zfs_fs";
+                mountpoint = "/nix";
+              };
+              "local/root" = {
+                type = "zfs_fs";
+                mountpoint = "/";
+                postCreateHook = "zfs list -t snapshot -H -o name | grep -E '^zroot/local/root@blank$' || zfs snapshot zroot/local/root@blank";
+              };
+
+              # backed up datasets
+              "safe" = {
+                type = "zfs_fs";
+                options.mountpoint = "none";
+              };
+              "safe/persist" = {
+                type = "zfs_fs";
+                mountpoint = "/persist";
+              };
+              "safe/home" = {
+                type = "zfs_fs";
+                mountpoint = "/home";
+              };
+            };
+          };
+        };
+      };
+    };
+}

--- a/modules/hosts/sunny/disko.nix
+++ b/modules/hosts/sunny/disko.nix
@@ -41,16 +41,10 @@
             value = {
               type = "disk";
               device = "/dev/${name}";
-              content = raidzContent // {
-                partitions = raidzContent.partitions // {
-                  ESP = raidzContent.partitions.ESP // {
-                    content = raidzContent.partitions.ESP.content // {
-                      mountpoint = # nvme1n1's ESP is mounted at /boot1, etc.
-                        raidzContent.partitions.ESP.content.mountpoint
-                        + (if index == 0 then "" else builtins.toString index);
-                    };
-                  };
-                };
+              content = lib.recursiveUpdate raidzContent {
+                partitions.ESP.content.mountpoint =
+                  raidzContent.partitions.ESP.content.mountpoint
+                  + (if index == 0 then "" else builtins.toString index);
               };
             };
           }) diskNames

--- a/modules/hosts/sunny/filesystems.nix
+++ b/modules/hosts/sunny/filesystems.nix
@@ -2,18 +2,18 @@
   flake.modules.nixos."nixosConfigurations/sunny" = {
     boot.initrd.availableKernelModules = [ "nvme" ];
 
-    fileSystems."/" = {
-      device = "/dev/disk/by-uuid/34724de5-e5c9-4546-aec0-9bd3635bce3d";
-      fsType = "ext4";
-    };
-
-    fileSystems."/boot" = {
-      device = "/dev/disk/by-uuid/2676-30F1";
-      fsType = "vfat";
-      options = [
-        "fmask=0022"
-        "dmask=0022"
-      ];
-    };
+    # fileSystems."/" = {
+    #   device = "/dev/disk/by-uuid/34724de5-e5c9-4546-aec0-9bd3635bce3d";
+    #   fsType = "ext4";
+    # };
+    #
+    # fileSystems."/boot" = {
+    #   device = "/dev/disk/by-uuid/2676-30F1";
+    #   fsType = "vfat";
+    #   options = [
+    #     "fmask=0022"
+    #     "dmask=0022"
+    #   ];
+    # };
   };
 }

--- a/modules/hosts/sunny/hardware.nix
+++ b/modules/hosts/sunny/hardware.nix
@@ -15,7 +15,7 @@
 
       boot = {
         # Use latest linux kernel
-        kernelPackages = pkgs.linuxPackages_latest;
+        # kernelPackages = pkgs.linuxPackages_latest;
 
         initrd = {
           availableKernelModules = [

--- a/modules/nixos/core/bootloader.nix
+++ b/modules/nixos/core/bootloader.nix
@@ -6,7 +6,7 @@
         grub = {
           enable = true;
           device = lib.mkDefault "nodev";
-	  zfsSupport = true;
+          zfsSupport = true;
         };
       };
     };

--- a/modules/nixos/core/impermanence.nix
+++ b/modules/nixos/core/impermanence.nix
@@ -1,6 +1,6 @@
 { inputs, ... }:
 {
-  flake.modules.nixos.impermanence = 
+  flake.modules.nixos.impermanence =
     { pkgs, ... }:
     {
       imports = [ inputs.impermanence.nixosModules.impermanence ];
@@ -11,7 +11,7 @@
           "/var/log"
           "/var/lib/nixos"
           "/var/lib/systemd/coredump"
-	  # TODO: move to modules
+          # TODO: move to modules
           "/var/lib/acme"
           "/etc/NetworkManager/system-connections"
         ];
@@ -25,11 +25,11 @@
         after = [ "zfs-import-zroot.service" ];
         before = [ "sysroot.mount" ];
         path = [ pkgs.zfs ];
-	unitConfig.DefaultDependencies = "no";
-	serviceConfig.Type = "oneshot";
-	script = ''
-	  zfs rollback -r zroot/local/root@blank && echo " >> >> Rollback Complete << <<"
-	'';
+        unitConfig.DefaultDependencies = "no";
+        serviceConfig.Type = "oneshot";
+        script = ''
+          	  zfs rollback -r zroot/local/root@blank && echo " >> >> Rollback Complete << <<"
+          	'';
       };
 
       services.zfs = {

--- a/modules/nixos/core/impermanence.nix
+++ b/modules/nixos/core/impermanence.nix
@@ -11,7 +11,9 @@
           "/var/log"
           "/var/lib/nixos"
           "/var/lib/systemd/coredump"
+	  # TODO: move to modules
           "/var/lib/acme"
+          "/etc/NetworkManager/system-connections"
         ];
       };
       fileSystems."/persist".neededForBoot = true;


### PR DESCRIPTION
Configure disko layout for `sunny` and `merry`.

Will enable impermanence after the disko layout is applied.

### TODO:

- [ ] -  create a disko/zfs module so new hosts only need a list of disks, zpool type, and an optional swap partition.
- [ ] -  manage ssh/wg keys and add to /persist